### PR TITLE
Fix Gradio Lightroom upload bug and clarify MMArt data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 ## 🧭 Navigation
 
 - [Overview](#-overview)
+- [Dataset Source FAQ](#-dataset-source-faq)
 - [Demo Videos](#-demo-videos)
 - [Checklist](#-checklist)
 - [Getting Started](#-getting-started)
@@ -100,6 +101,18 @@
 </div>
 
 JarvisArt is a multi-modal large language model (MLLM)-driven agent for intelligent photo retouching. It is designed to liberate human creativity by understanding user intent, mimicking the reasoning of professional artists, and coordinating over 200 tools in Adobe Lightroom. JarvisArt utilizes a novel two-stage training framework, starting with Chain-of-Thought supervised fine-tuning for foundational reasoning, followed by Group Relative Policy Optimization for Retouching (GRPO-R) to enhance its decision-making and tool proficiency. Supported by the newly created MMArt dataset (55K samples) and MMArt-Bench, JarvisArt demonstrates superior performance, outperforming GPT-4o with a 60% improvement in pixel-level metrics for content fidelity while maintaining comparable instruction-following capabilities.
+
+---
+
+## 📦 Dataset Source FAQ
+
+To clarify data provenance for MMArt (including the distribution summary shown in the paper):
+
+- As described in the paper, MMArt is constructed from **PPR10K**, Adobe Lightroom community assets, and licensed open-source collections.
+- In this repository, the currently public dataset releases are:
+  - [MMArt-PPR10K](https://huggingface.co/datasets/JarvisArt/MMArt-PPR10k)
+  - [MMArt-Bench](https://huggingface.co/datasets/JarvisArt/MMArt-Bench)
+- A full per-source breakdown list for every subset in Figure 9 is not yet published in this repository.
 
 ---
 

--- a/lrc_scripts/clients/agent_to_lightroom/lrc_api_server.py
+++ b/lrc_scripts/clients/agent_to_lightroom/lrc_api_server.py
@@ -6,6 +6,11 @@ from pathlib import Path
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import json
 import urllib.parse
+import cgi
+import io
+import shutil
+
+UPLOAD_ROOT = Path("/tmp/lightroom_uploads")
 
 class LightroomAPI:
     def __init__(self, host="127.0.0.1", port=7878):
@@ -183,19 +188,108 @@ def test_server_connection(api):
     return False
 
 class PhotoProcessHandler(BaseHTTPRequestHandler):
-    def do_POST(self):
-        content_length = int(self.headers['Content-Length'])
-        post_data = self.rfile.read(content_length)
-        data = json.loads(post_data.decode('utf-8'))
-        
-        photo_path = data.get('photo_path')
-        xmp_path = data.get('xmp_path')
-        
-        if not photo_path or not xmp_path:
-            self.send_error(400, "Missing photo_path or xmp_path")
-            return
-            
+    @staticmethod
+    def parse_json_payload(raw_payload):
+        """Parse JSON body."""
+        if not raw_payload:
+            raise ValueError("Empty request body")
         try:
+            return json.loads(raw_payload.decode("utf-8"))
+        except UnicodeDecodeError as exc:
+            raise ValueError("JSON body must be UTF-8 encoded") from exc
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON body: {exc.msg}") from exc
+
+    @staticmethod
+    def _safe_filename(name, fallback):
+        """Prevent path traversal in uploaded filenames."""
+        if not name:
+            return fallback
+        cleaned = Path(name).name
+        return cleaned or fallback
+
+    @staticmethod
+    def _get_form_part(form, *names):
+        for name in names:
+            if name in form:
+                part = form[name]
+                if isinstance(part, list):
+                    return part[0]
+                return part
+        return None
+
+    @classmethod
+    def parse_multipart_payload(cls, raw_payload, content_type, upload_root=UPLOAD_ROOT):
+        """Parse multipart body and store uploaded files."""
+        environ = {
+            "REQUEST_METHOD": "POST",
+            "CONTENT_TYPE": content_type,
+            "CONTENT_LENGTH": str(len(raw_payload)),
+        }
+        form = cgi.FieldStorage(
+            fp=io.BytesIO(raw_payload),
+            environ=environ,
+            keep_blank_values=True,
+        )
+
+        photo_part = cls._get_form_part(form, "photo_file")
+        preset_part = cls._get_form_part(form, "lua_file", "xmp_file")
+        if photo_part is None or preset_part is None:
+            raise ValueError("Missing photo_file or lua_file/xmp_file in multipart request")
+        if getattr(photo_part, "file", None) is None or getattr(preset_part, "file", None) is None:
+            raise ValueError("Invalid multipart upload payload")
+
+        task_id = form.getfirst("task_id") or f"task_{int(time.time())}"
+        upload_dir = Path(upload_root) / task_id
+        upload_dir.mkdir(parents=True, exist_ok=True)
+
+        photo_filename = cls._safe_filename(
+            form.getfirst("photo_filename") or photo_part.filename,
+            "photo_upload",
+        )
+        preset_filename = cls._safe_filename(
+            form.getfirst("lua_filename")
+            or form.getfirst("xmp_filename")
+            or preset_part.filename,
+            "preset_upload.lua",
+        )
+
+        photo_path = upload_dir / photo_filename
+        preset_path = upload_dir / preset_filename
+
+        with open(photo_path, "wb") as photo_file:
+            shutil.copyfileobj(photo_part.file, photo_file)
+        with open(preset_path, "wb") as preset_file:
+            shutil.copyfileobj(preset_part.file, preset_file)
+
+        return {
+            "photo_path": str(photo_path),
+            "xmp_path": str(preset_path),
+            "task_id": task_id,
+        }
+
+    @staticmethod
+    def extract_photo_and_preset_paths(data):
+        photo_path = data.get("photo_path")
+        preset_path = data.get("xmp_path") or data.get("lua_path")
+        return photo_path, preset_path
+
+    def do_POST(self):
+        try:
+            content_type = self.headers.get("Content-Type", "").lower()
+            content_length = int(self.headers.get("Content-Length", "0"))
+            raw_payload = self.rfile.read(content_length)
+
+            if "multipart/form-data" in content_type:
+                data = self.parse_multipart_payload(raw_payload, self.headers.get("Content-Type", ""))
+            else:
+                data = self.parse_json_payload(raw_payload)
+
+            photo_path, preset_path = self.extract_photo_and_preset_paths(data)
+            if not photo_path or not preset_path:
+                self.send_error(400, "Missing photo_path or xmp_path/lua_path")
+                return
+
             # 为每个任务创建专用的输出目录 - Mac本地路径
             task_id = data.get('task_id', f"task_{int(time.time())}")
             import platform
@@ -204,7 +298,7 @@ class PhotoProcessHandler(BaseHTTPRequestHandler):
             else:
                 output_dir = f"/tmp/lightroom_processed/{task_id}"
             
-            result, output_path = self.server.lightroom_api.process_photo(photo_path, xmp_path, output_dir)
+            result, output_path = self.server.lightroom_api.process_photo(photo_path, preset_path, output_dir)
             if result:
                 response_data = {
                     "status": "success",
@@ -218,6 +312,8 @@ class PhotoProcessHandler(BaseHTTPRequestHandler):
                 self.wfile.write(json.dumps(response_data).encode())
             else:
                 self.send_error(500, "Failed to process photo")
+        except ValueError as e:
+            self.send_error(400, str(e))
         except Exception as e:
             self.send_error(500, str(e))
 

--- a/lrc_scripts/clients/agent_to_lightroom/tests/test_lrc_api_server.py
+++ b/lrc_scripts/clients/agent_to_lightroom/tests/test_lrc_api_server.py
@@ -1,0 +1,77 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "lrc_api_server.py"
+spec = importlib.util.spec_from_file_location("lrc_api_server", MODULE_PATH)
+lrc_api_server = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(lrc_api_server)
+
+
+def build_multipart_body(boundary: str, fields: Dict[str, str], files: Dict[str, Tuple[str, bytes, str]]) -> bytes:
+    chunks: List[bytes] = []
+    for key, value in fields.items():
+        chunks.extend(
+            [
+                f"--{boundary}\r\n".encode(),
+                f'Content-Disposition: form-data; name="{key}"\r\n\r\n'.encode(),
+                f"{value}\r\n".encode(),
+            ]
+        )
+
+    for key, (filename, content, content_type) in files.items():
+        chunks.extend(
+            [
+                f"--{boundary}\r\n".encode(),
+                f'Content-Disposition: form-data; name="{key}"; filename="{filename}"\r\n'.encode(),
+                f"Content-Type: {content_type}\r\n\r\n".encode(),
+                content,
+                b"\r\n",
+            ]
+        )
+
+    chunks.append(f"--{boundary}--\r\n".encode())
+    return b"".join(chunks)
+
+
+class RequestParsingTests(unittest.TestCase):
+    def test_parse_json_payload_supports_lua_path(self):
+        payload = b'{"photo_path":"/tmp/photo.jpg","lua_path":"/tmp/preset.lua"}'
+
+        request_data = lrc_api_server.PhotoProcessHandler.parse_json_payload(payload)
+        photo_path, preset_path = lrc_api_server.PhotoProcessHandler.extract_photo_and_preset_paths(request_data)
+
+        self.assertEqual(photo_path, "/tmp/photo.jpg")
+        self.assertEqual(preset_path, "/tmp/preset.lua")
+
+    def test_parse_multipart_payload_handles_binary_upload(self):
+        boundary = "----JarvisArtBoundary"
+        body = build_multipart_body(
+            boundary=boundary,
+            fields={"mode": "upload", "task_id": "task_123"},
+            files={
+                "photo_file": ("photo.jpg", b"\xff\xd8\xff\xe0\x00\x10JPEG", "image/jpeg"),
+                "lua_file": ("preset.lua", b"return {Exposure2012 = 0.25}", "text/plain"),
+            },
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            request_data = lrc_api_server.PhotoProcessHandler.parse_multipart_payload(
+                raw_payload=body,
+                content_type=f"multipart/form-data; boundary={boundary}",
+                upload_root=Path(tmp_dir),
+            )
+
+            photo_path = Path(request_data["photo_path"])
+            preset_path = Path(request_data["xmp_path"])
+
+            self.assertTrue(photo_path.exists())
+            self.assertTrue(preset_path.exists())
+            self.assertEqual(photo_path.read_bytes(), b"\xff\xd8\xff\xe0\x00\x10JPEG")
+            self.assertEqual(preset_path.read_text(encoding="utf-8"), "return {Exposure2012 = 0.25}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix `lrc_api_server.py` to route POST parsing by `Content-Type` instead of always decoding as UTF-8 JSON
- add multipart upload support for `photo_file` + `lua_file`/`xmp_file` and local JSON compatibility for both `xmp_path` and `lua_path`
- add unit tests covering JSON and binary multipart parsing paths
- add a `Dataset Source FAQ` section in README to clarify current public MMArt data source information

## Verification
- `python -m unittest discover -s lrc_scripts/clients/agent_to_lightroom/tests -v`

Closes #34
Addresses #33
