### PR TITLE
Refine MMArt dataset source wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ JarvisArt is a multi-modal large language model (MLLM)-driven agent for intellig
 
 To clarify data provenance for MMArt (including the distribution summary shown in the paper):
 
-- As described in the paper, MMArt is constructed from **PPR10K**, Adobe Lightroom community assets, and licensed open-source collections.
+- As described in the paper, MMArt is constructed from **PPR10K** and other licensed open-source collections.
 - In this repository, the currently public dataset releases are:
   - [MMArt-PPR10K](https://huggingface.co/datasets/JarvisArt/MMArt-PPR10k)
   - [MMArt-Bench](https://huggingface.co/datasets/JarvisArt/MMArt-Bench)


### PR DESCRIPTION
Remove the phrase "Adobe Lightroom community assets" from README's Dataset Source FAQ and keep the wording as: "PPR10K and other licensed open-source collections."

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change clarifying dataset provenance; no code or behavior changes.
> 
> **Overview**
> **Documentation clarification:** Updates the `README.md` *Dataset Source FAQ* to state MMArt is constructed from **PPR10K** and other licensed open-source collections, removing the prior reference to “Adobe Lightroom community assets.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a4b26a45a89318cb96d7c57adbea00dd1fb88b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->